### PR TITLE
Add docstrings to BMI classes

### DIFF
--- a/bmi/bmi.py
+++ b/bmi/bmi.py
@@ -186,41 +186,6 @@ class Bmi(object):
         """
         pass
 
-    def get_var_rank(self, long_var_name):
-        """Returns the number of dimensions of the given variable.
-
-        Scalars have a rank of 0, vectors a rank of 1, planar grids
-        and meshes a rank of 2, and 3D grids and meshes a rank of 3.
-
-        Parameters
-        ----------
-        long_var_name : str
-          An input or output variable name, a CSDMS Standard Name.
-
-        Returns
-        -------
-        int
-          The variable rank.
-
-        """
-        pass
-
-    def get_var_size(self, long_var_name):
-        """Returns the number of elements in the given variable.
-
-        Parameters
-        ----------
-        long_var_name : str
-          An input or output variable name, a CSDMS Standard Name.
-
-        Returns
-        -------
-        int
-          The count of elements in the variable.
-
-        """
-        pass
-
     def get_var_nbytes(self, long_var_name):
         """Returns the size, in bytes, of the given variable.
 
@@ -233,6 +198,61 @@ class Bmi(object):
         -------
         int
           The size of the variable, counted in bytes.
+
+        """
+        pass
+
+    def get_var_grid(self, long_var_name):
+        """Returns the identifier of the grid associated with a given
+        variable.
+
+        Parameters
+        ----------
+        long_var_name : str
+          An input or output variable name, a CSDMS Standard Name.
+
+        Returns
+        -------
+        int
+          The grid identifier.
+
+        """
+        pass
+
+    def get_grid_rank(self, long_var_name):
+        """Returns the number of dimensions of the grid associated with a
+        given variable.
+
+        Scalars have a rank of 0, vectors a rank of 1, planar grids
+        and meshes a rank of 2, and volumetric grids and meshes a rank
+        of 3.
+
+        Parameters
+        ----------
+        long_var_name : str
+          An input or output variable name, a CSDMS Standard Name.
+
+        Returns
+        -------
+        int
+          The grid rank.
+
+        """
+        pass
+
+    def get_grid_size(self, long_var_name):
+        """Returns the number of elements in the grid associated with a given
+        variable.
+
+        Parameters
+        ----------
+        long_var_name : str
+          An input or output variable name, a CSDMS Standard Name.
+
+        Returns
+        -------
+        int
+          The grid node count.
 
         """
         pass

--- a/bmi/bmi.py
+++ b/bmi/bmi.py
@@ -18,22 +18,21 @@ class Bmi(object):
 
         Initialize() performs all tasks that take place before
         entering the model's time loop, including opening files and
-        initializing the model state. Models should be refactored, if
-        necessary, to read their inputs from a text-based
-        configuration file, specified by `filename`. CSDMS does not
-        impose any constraint on how configuration files are formatted
-        (although YAML is recommended). A "template" of a model's
-        configuration file with placeholder values is used by the BMI.
+        initializing the model state. Model inputs are read from a
+        text-based configuration file, specified by `filename`.
 
         Parameters
         ----------
         filename : str, optional
           The path to the model configuration file.
 
-        Returns
-        -------
-        int
-          Non-zero value indicates error code, or zero on success.
+        Notes
+        -----
+        Models should be refactored, if necessary, to use a
+        configuration file. CSDMS does not impose any constraint on
+        how configuration files are formatted, although YAML is
+        recommended. A template of a model's configuration file
+        with placeholder values is used by the BMI.
 
         """
         pass
@@ -48,21 +47,36 @@ class Bmi(object):
         computed by the ***initialize()*** method and this method can
         return with no action.
 
-        Returns
-        -------
-        int
-          Non-zero value indicates error code, or zero on success.
-
         """
         pass
 
     def update_until(self, time):
-        """Advances model state until the given time step.
+        """Advances model state until the given time.
+
+        Parameters
+        ----------
+        time : double
+          A model time value.
+
+        See Also
+        --------
+        update
+
         """
         pass
 
     def update_frac(self, time_frac):
         """Advances model state by a fraction of a time step.
+
+        Parameters
+        ----------
+        time_frac : double
+          A fraction of a model time step value.
+
+        See Also
+        --------
+        update
+
         """
         pass
 
@@ -73,98 +87,289 @@ class Bmi(object):
         the model's time loop. This typically includes deallocating
         memory, closing files and printing reports.
 
-        Returns
-        -------
-        int
-          Non-zero value indicates error code, or zero on success.
-
         """
         pass
 
     def get_component_name(self):
         """Returns the name of the component.
+
+        Returns
+        -------
+        str
+          The name of the component.
+
         """
         pass
 
     def get_input_var_names(self):
         """Lists the model's input variables.
+
+        Input variable names must be CSDMS Standard Names, also known
+        as *long variable names*.
+
+        Returns
+        -------
+        list of str
+          The input variables for the model.
+
+        Notes
+        -----
+        Standard Names enable the CSDMS framework to determine whether
+        an input variable in one model is equivalent to, or compatible
+        with, an output variable in another model. This allows the
+        framework to automatically connect components.
+
+        Standard Names do not have to be used within the model.
+
         """
         pass
 
     def get_output_var_names(self):
         """Lists the model's output variables.
+
+        Output variable names must be CSDMS Standard Names, also known
+        as *long variable names*.
+
+        Returns
+        -------
+        list of str
+          The output variables for the model.
+
+        See Also
+        --------
+        get_input_var_names
+
         """
         pass
 
     def get_var_type(self, long_var_name):
         """Returns the type of the given variable.
+
+        Parameters
+        ----------
+        long_var_name : str
+          An input or output variable name, a CSDMS Standard Name.
+
+        Returns
+        -------
+        str
+          The Python variable type; e.g., `str`, `int`, `float`.
+
         """
         pass
 
     def get_var_units(self, long_var_name):
         """Returns the units of the given variable.
+
+        Standard unit names, in lower case, should be used, such as
+        "meters" or "seconds". Standard abbreviations, like "m" for
+        meters, are also supported. For variables with compound units,
+        each unit name is separated by a single space, with exponents
+        other than 1 placed immediately after the name, as in "m s-1"
+        for velocity, "W m-2" for an energy flux, or "km2" for an
+        area.
+
+        Parameters
+        ----------
+        long_var_name : str
+          An input or output variable name, a CSDMS Standard Name.
+
+        Returns
+        -------
+        str
+          The variable units.
+
+        Notes
+        -----
+        CSDMS uses the UDUNITS standard from Unidata.
+
         """
         pass
 
     def get_var_rank(self, long_var_name):
         """Returns the number of dimensions of the given variable.
+
+        Scalars have a rank of 0, vectors a rank of 1, planar grids
+        and meshes a rank of 2, and 3D grids and meshes a rank of 3.
+
+        Parameters
+        ----------
+        long_var_name : str
+          An input or output variable name, a CSDMS Standard Name.
+
+        Returns
+        -------
+        int
+          The variable rank.
+
         """
         pass
 
     def get_var_size(self, long_var_name):
         """Returns the number of elements in the given variable.
+
+        Parameters
+        ----------
+        long_var_name : str
+          An input or output variable name, a CSDMS Standard Name.
+
+        Returns
+        -------
+        int
+          The count of elements in the variable.
+
         """
         pass
 
     def get_var_nbytes(self, long_var_name):
         """Returns the size, in bytes, of the given variable.
+
+        Parameters
+        ----------
+        long_var_name : str
+          An input or output variable name, a CSDMS Standard Name.
+
+        Returns
+        -------
+        int
+          The size of the variable, counted in bytes.
+
         """
         pass
 
     def get_start_time(self):
         """Returns the start time of the model.
+
+        Model times should be of type float. The default model start
+        time is 0.
+
+        Returns
+        -------
+        float
+          The model start time.
+
         """
         pass
 
     def get_current_time(self):
         """Returns the model's current time.
+
+        Returns
+        -------
+        float
+          The current model time.
+
+        See Also
+        --------
+        get_start_time
+
         """
         pass
 
     def get_end_time(self):
-        """Returns the end time of the model.
+        """Returns the maximum time of the model.
+
+        Returns
+        -------
+        float
+          The maximum model time.
+
+        See Also
+        --------
+        get_start_time
+
         """
         pass
 
     def get_time_step(self):
         """Returns the model's current time step.
+
+        The model time step should be of type float. The default time
+        step is 1.0.
+
+        Returns
+        -------
+        float
+          The time step used in model.
+
         """
         pass
 
     def get_time_units(self):
         """Returns the model's time units.
+
+        Returns
+        -------
+        float
+          The model time unit; e.g., 'days' or 's'.
+
+        See Also
+        --------
+        get_var_units
+
         """
         pass
 
     def get_value(self, long_var_name):
         """Returns the value of the given variable.
+
+        This is the getter for the model, used to access the model's
+        current state. It returns the value of a model variable, with
+        the return type, size and rank dependent on the variable.
+
+        Parameters
+        ----------
+        long_var_name : str
+          An input or output variable name, a CSDMS Standard Name.
+
         """
         pass
 
     def get_value_at_indices(self, long_var_name, inds):
         """Returns the value of the given variable at a location in the model
         grid.
+
+        Parameters
+        ----------
+        long_var_name : str
+          An input or output variable name, a CSDMS Standard Name.
+        inds : array_like
+          The indices into the variable array.
+
         """
         pass
 
     def set_value(self, long_var_name, src):
         """Specifies a new value for a model variable.
+
+        This is the setter for the model, used to change the model's
+        current state. It accepts, through `src`, a new value for a
+        model variable, with the type, size and rank of `src`
+        dependent on the variable.
+
+        Parameters
+        ----------
+        long_var_name : str
+          An input or output variable name, a CSDMS Standard Name.
+        src : array_like
+          The new value for the specified variable.
+
         """
         pass
 
     def set_value_at_indices(self, long_var_name, inds, src):
         """Specifies a new value for a model variable at a location in the
         model grid.
+
+        Parameters
+        ----------
+        long_var_name : str
+          An input or output variable name, a CSDMS Standard Name.
+        inds : array_like
+          The indices into the variable array.
+        src : array_like
+          The new value for the specified variable.
+
         """
         pass
 

--- a/bmi/bmi.py
+++ b/bmi/bmi.py
@@ -15,11 +15,44 @@ class Bmi(object):
 
     def initialize(self, filename):
         """Performs startup tasks for the model.
+
+        Initialize() performs all tasks that take place before
+        entering the model's time loop, including opening files and
+        initializing the model state. Models should be refactored, if
+        necessary, to read their inputs from a text-based
+        configuration file, specified by `filename`. CSDMS does not
+        impose any constraint on how configuration files are formatted
+        (although YAML is recommended). A "template" of a model's
+        configuration file with placeholder values is used by the BMI.
+
+        Parameters
+        ----------
+        filename : str, optional
+          The path to the model configuration file.
+
+        Returns
+        -------
+        int
+          Non-zero value indicates error code, or zero on success.
+
         """
         pass
 
     def update(self):
         """Advances model state by one time step.
+
+        Update() performs all tasks that take place within one pass
+        through the model's time loop. This typically includes
+        incrementing all of the model's state variables. If the
+        model's state variables don't change in time, then they can be
+        computed by the ***initialize()*** method and this method can
+        return with no action.
+
+        Returns
+        -------
+        int
+          Non-zero value indicates error code, or zero on success.
+
         """
         pass
 
@@ -35,6 +68,16 @@ class Bmi(object):
 
     def finalize(self):
         """Performs tear-down tasks for the model.
+
+        Finalize() performs all tasks that take place after exiting
+        the model's time loop. This typically includes deallocating
+        memory, closing files and printing reports.
+
+        Returns
+        -------
+        int
+          Non-zero value indicates error code, or zero on success.
+
         """
         pass
 

--- a/bmi/bmi.py
+++ b/bmi/bmi.py
@@ -423,17 +423,17 @@ class BmiRaster(Bmi):
     """Defines an interface for a uniform rectilinear grid.
     """
 
-    def get_grid_shape(self, long_var_name):
+    def get_grid_shape(self, grid_id):
         """Returns the dimensions of the computational grid.
         """
         pass
 
-    def get_grid_spacing(self, long_var_name):
+    def get_grid_spacing(self, grid_id):
         """Returns the spacing between nodes of the computational grid.
         """
         pass
 
-    def get_grid_origin(self, long_var_name):
+    def get_grid_origin(self, grid_id):
         """Returns coordinates for the origin of the computational grid.
         """
         pass
@@ -444,22 +444,22 @@ class BmiRectilinear(Bmi):
     spacing.
     """
 
-    def get_grid_shape(self, long_var_name):
+    def get_grid_shape(self, grid_id):
         """Returns the dimensions of the computational grid.
         """
         pass
 
-    def get_grid_x(self, long_var_name):
+    def get_grid_x(self, grid_id):
         """Returns the grid nodes in the streamwise direction.
         """
         pass
 
-    def get_grid_y(self, long_var_name):
+    def get_grid_y(self, grid_id):
         """Returns the grid nodes in the transverse direction.
         """
         pass
 
-    def get_grid_z(self, long_var_name):
+    def get_grid_z(self, grid_id):
         """Returns the grid nodes in the normal direction.
         """
         pass
@@ -470,22 +470,22 @@ class BmiStructured (Bmi):
     spacing of nodes.
     """
 
-    def get_grid_shape(self, long_var_name):
+    def get_grid_shape(self, grid_id):
         """Returns the dimensions of the computational grid.
         """
         pass
 
-    def get_grid_x(self, long_var_name):
+    def get_grid_x(self, grid_id):
         """Returns the grid nodes in the streamwise direction.
         """
         pass
 
-    def get_grid_y(self, long_var_name):
+    def get_grid_y(self, grid_id):
         """Returns the grid nodes in the transverse direction.
         """
         pass
 
-    def get_grid_z(self, long_var_name):
+    def get_grid_z(self, grid_id):
         """Returns the grid nodes in the normal direction.
         """
         pass
@@ -495,27 +495,27 @@ class BmiUnstructured(Bmi):
     """Defines an interface for an unstructured mesh of nodes.
     """
 
-    def get_grid_x(self, long_var_name):
+    def get_grid_x(self, grid_id):
         """Returns the grid nodes in the streamwise direction.
         """
         pass
 
-    def get_grid_y(self, long_var_name):
+    def get_grid_y(self, grid_id):
         """Returns the grid nodes in the transverse direction.
         """
         pass
 
-    def get_grid_z(self, long_var_name):
+    def get_grid_z(self, grid_id):
         """Returns the grid nodes in the normal direction.
         """
         pass
 
-    def get_grid_connectivity(self, long_var_name):
+    def get_grid_connectivity(self, grid_id):
         """Returns connectivity array of the grid.
         """
         pass
 
-    def get_grid_offset(self, long_var_name):
+    def get_grid_offset(self, grid_id):
         """Returns the grid offset values.
         """
         pass

--- a/bmi/bmi.py
+++ b/bmi/bmi.py
@@ -313,14 +313,39 @@ class Bmi(object):
     def get_value(self, long_var_name):
         """Returns the value of the given variable.
 
-        This is the getter for the model, used to access the model's
-        current state. It returns the value of a model variable, with
+        This is a getter for the model, used to access the model's
+        current state. It returns a copy of a model variable, with
         the return type, size and rank dependent on the variable.
 
         Parameters
         ----------
         long_var_name : str
           An input or output variable name, a CSDMS Standard Name.
+
+        Returns
+        -------
+        object
+          The value of a model variable.
+
+        """
+        pass
+
+    def get_value_ref(self, long_var_name):
+        """Returns a given variable.
+
+        This is a getter for the model, used to access the model's
+        current state. It returns a reference to a model variable,
+        with the return type, size and rank dependent on the variable.
+
+        Parameters
+        ----------
+        long_var_name : str
+          An input or output variable name, a CSDMS Standard Name.
+
+        Returns
+        -------
+        object
+          A model variable.
 
         """
         pass

--- a/bmi/bmi.py
+++ b/bmi/bmi.py
@@ -9,124 +9,220 @@ class BmiGridType(object):
 
 
 class Bmi(object):
+    """Defines an interface for converting a standalone model into an
+    integrated modeling framework component.
+    """
+
     def initialize(self, filename):
+        """Performs startup tasks for the model.
+        """
         pass
 
     def update(self):
+        """Advances model state by one time step.
+        """
         pass
 
     def update_until(self, time):
+        """Advances model state until the given time step.
+        """
         pass
 
     def update_frac(self, time_frac):
+        """Advances model state by a fraction of a time step.
+        """
         pass
 
     def finalize(self):
+        """Performs tear-down tasks for the model.
+        """
         pass
 
     def get_component_name(self):
+        """Returns the name of the component.
+        """
         pass
 
     def get_input_var_names(self):
+        """Lists the model's input variables.
+        """
         pass
 
     def get_output_var_names(self):
+        """Lists the model's output variables.
+        """
         pass
 
     def get_var_type(self, long_var_name):
+        """Returns the type of the given variable.
+        """
         pass
 
     def get_var_units(self, long_var_name):
+        """Returns the units of the given variable.
+        """
         pass
 
     def get_var_rank(self, long_var_name):
+        """Returns the number of dimensions of the given variable.
+        """
         pass
 
     def get_var_size(self, long_var_name):
+        """Returns the number of elements in the given variable.
+        """
         pass
 
     def get_var_nbytes(self, long_var_name):
+        """Returns the size, in bytes, of the given variable.
+        """
         pass
 
     def get_start_time(self):
+        """Returns the start time of the model.
+        """
         pass
 
     def get_current_time(self):
+        """Returns the model's current time.
+        """
         pass
 
     def get_end_time(self):
+        """Returns the end time of the model.
+        """
         pass
 
     def get_time_step(self):
+        """Returns the model's current time step.
+        """
         pass
 
     def get_time_units(self):
+        """Returns the model's time units.
+        """
         pass
 
     def get_value(self, long_var_name):
+        """Returns the value of the given variable.
+        """
         pass
 
     def get_value_at_indices(self, long_var_name, inds):
+        """Returns the value of the given variable at a location in the model
+        grid.
+        """
         pass
 
     def set_value(self, long_var_name, src):
+        """Specifies a new value for a model variable.
+        """
         pass
 
     def set_value_at_indices(self, long_var_name, inds, src):
+        """Specifies a new value for a model variable at a location in the
+        model grid.
+        """
         pass
 
 
 class BmiRaster(Bmi):
+    """Defines an interface for a uniform rectilinear grid.
+    """
+
     def get_grid_shape(self, long_var_name):
+        """Returns the dimensions of the computational grid.
+        """
         pass
 
     def get_grid_spacing(self, long_var_name):
+        """Returns the spacing between nodes of the computational grid.
+        """
         pass
 
     def get_grid_origin(self, long_var_name):
+        """Returns coordinates for the origin of the computational grid.
+        """
         pass
 
 
 class BmiRectilinear(Bmi):
+    """Defines an interface for a rectilinear grid with nonuniform
+    spacing.
+    """
+
     def get_grid_shape(self, long_var_name):
+        """Returns the dimensions of the computational grid.
+        """
         pass
 
     def get_grid_x(self, long_var_name):
+        """Returns the grid nodes in the streamwise direction.
+        """
         pass
 
     def get_grid_y(self, long_var_name):
+        """Returns the grid nodes in the transverse direction.
+        """
         pass
 
     def get_grid_z(self, long_var_name):
+        """Returns the grid nodes in the normal direction.
+        """
         pass
 
 
 class BmiStructured (Bmi):
+    """Defines an interface for a grid with nonuniform position and
+    spacing of nodes.
+    """
+
     def get_grid_shape(self, long_var_name):
+        """Returns the dimensions of the computational grid.
+        """
         pass
 
     def get_grid_x(self, long_var_name):
+        """Returns the grid nodes in the streamwise direction.
+        """
         pass
 
     def get_grid_y(self, long_var_name):
+        """Returns the grid nodes in the transverse direction.
+        """
         pass
 
     def get_grid_z(self, long_var_name):
+        """Returns the grid nodes in the normal direction.
+        """
         pass
 
 
 class BmiUnstructured(Bmi):
+    """Defines an interface for an unstructured mesh of nodes.
+    """
+
     def get_grid_x(self, long_var_name):
+        """Returns the grid nodes in the streamwise direction.
+        """
         pass
 
     def get_grid_y(self, long_var_name):
+        """Returns the grid nodes in the transverse direction.
+        """
         pass
 
     def get_grid_z(self, long_var_name):
+        """Returns the grid nodes in the normal direction.
+        """
         pass
 
     def get_grid_connectivity(self, long_var_name):
+        """Returns connectivity array of the grid.
+        """
         pass
 
     def get_grid_offset(self, long_var_name):
+        """Returns the grid offset values.
+        """
         pass

--- a/bmi/bmi.py
+++ b/bmi/bmi.py
@@ -425,16 +425,49 @@ class BmiRaster(Bmi):
 
     def get_grid_shape(self, grid_id):
         """Returns the dimensions of the computational grid.
+
+        Parameters
+        ----------
+        grid_id : int
+          A grid identifier.
+
+        Returns
+        -------
+        tuple of int
+          The dimensions of the grid.
+
         """
         pass
 
     def get_grid_spacing(self, grid_id):
-        """Returns the spacing between nodes of the computational grid.
+        """Returns the distance between nodes of the computational grid.
+
+        Parameters
+        ----------
+        grid_id : int
+          A grid identifier.
+
+        Returns
+        -------
+        tuple of float
+          The grid spacing.
+
         """
         pass
 
     def get_grid_origin(self, grid_id):
         """Returns coordinates for the origin of the computational grid.
+
+        Parameters
+        ----------
+        grid_id : int
+          A grid identifier.
+
+        Returns
+        -------
+        tuple of float
+          The coordinates of the lower left corner of the grid.
+
         """
         pass
 
@@ -446,21 +479,65 @@ class BmiRectilinear(Bmi):
 
     def get_grid_shape(self, grid_id):
         """Returns the dimensions of the computational grid.
+
+        Parameters
+        ----------
+        grid_id : int
+          A grid identifier.
+
+        Returns
+        -------
+        tuple of int
+          The dimensions of the grid.
+
         """
         pass
 
     def get_grid_x(self, grid_id):
         """Returns the grid nodes in the streamwise direction.
+
+        Parameters
+        ----------
+        grid_id : int
+          A grid identifier.
+
+        Returns
+        -------
+        tuple of float
+          The positions of the grid nodes.
+
         """
         pass
 
     def get_grid_y(self, grid_id):
         """Returns the grid nodes in the transverse direction.
+
+        Parameters
+        ----------
+        grid_id : int
+          A grid identifier.
+
+        Returns
+        -------
+        tuple of float
+          The positions of the grid nodes.
+
         """
         pass
 
     def get_grid_z(self, grid_id):
         """Returns the grid nodes in the normal direction.
+
+        Parameters
+        ----------
+        grid_id : int
+          A grid identifier.
+
+        Returns
+        -------
+        tuple of float
+          The positions of the grid nodes.
+
         """
         pass
 
@@ -472,21 +549,65 @@ class BmiStructured (Bmi):
 
     def get_grid_shape(self, grid_id):
         """Returns the dimensions of the computational grid.
+
+        Parameters
+        ----------
+        grid_id : int
+          A grid identifier.
+
+        Returns
+        -------
+        tuple of int
+          The dimensions of the grid.
+
         """
         pass
 
     def get_grid_x(self, grid_id):
         """Returns the grid nodes in the streamwise direction.
+
+        Parameters
+        ----------
+        grid_id : int
+          A grid identifier.
+
+        Returns
+        -------
+        array_like of float
+          The positions of the grid nodes.
+
         """
         pass
 
     def get_grid_y(self, grid_id):
         """Returns the grid nodes in the transverse direction.
+
+        Parameters
+        ----------
+        grid_id : int
+          A grid identifier.
+
+        Returns
+        -------
+        array_like of float
+          The positions of the grid nodes.
+
         """
         pass
 
     def get_grid_z(self, grid_id):
         """Returns the grid nodes in the normal direction.
+
+        Parameters
+        ----------
+        grid_id : int
+          A grid identifier.
+
+        Returns
+        -------
+        array_like of float
+          The positions of the grid nodes.
+
         """
         pass
 
@@ -497,25 +618,80 @@ class BmiUnstructured(Bmi):
 
     def get_grid_x(self, grid_id):
         """Returns the grid nodes in the streamwise direction.
+
+        Parameters
+        ----------
+        grid_id : int
+          A grid identifier.
+
+        Returns
+        -------
+        array_like of float
+          The positions of the grid nodes.
+
         """
         pass
 
     def get_grid_y(self, grid_id):
         """Returns the grid nodes in the transverse direction.
+
+        Parameters
+        ----------
+        grid_id : int
+          A grid identifier.
+
+        Returns
+        -------
+        array_like of float
+          The positions of the grid nodes.
+
         """
         pass
 
     def get_grid_z(self, grid_id):
         """Returns the grid nodes in the normal direction.
+
+        Parameters
+        ----------
+        grid_id : int
+          A grid identifier.
+
+        Returns
+        -------
+        array_like of float
+          The positions of the grid nodes.
+
         """
         pass
 
     def get_grid_connectivity(self, grid_id):
-        """Returns connectivity array of the grid.
+        """Returns the connectivity array of the grid.
+
+        Parameters
+        ----------
+        grid_id : int
+          A grid identifier.
+
+        Returns
+        -------
+        array_like of float
+          The graph of connections between the grid nodes.
+
         """
         pass
 
     def get_grid_offset(self, grid_id):
-        """Returns the grid offset values.
+        """Returns the offsets for the grid nodes.
+
+        Parameters
+        ----------
+        grid_id : int
+          A grid identifier.
+
+        Returns
+        -------
+        array_like of int
+          The offsets for the grid nodes.
+
         """
         pass

--- a/heat/bmi_heat.py
+++ b/heat/bmi_heat.py
@@ -54,14 +54,14 @@ class BmiHeat(Bmi):
     def get_var_units(self, var_name):
         return self._var_units[var_name]
 
-    def get_var_rank(self, var_name):
-        return self.get_value_ptr(var_name).ndim
-
-    def get_var_size(self, var_name):
-        return self.get_value_ptr(var_name).size
-
     def get_var_nbytes(self, var_name):
         return self.get_value_ptr(var_name).nbytes
+
+    def get_grid_rank(self, var_name):
+        return self.get_value_ptr(var_name).ndim
+
+    def get_grid_size(self, var_name):
+        return self.get_value_ptr(var_name).size
 
     def get_value_ptr(self, var_name):
         return self._values[var_name]

--- a/heat/bmi_heat.py
+++ b/heat/bmi_heat.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+5#! /usr/bin/env python
 import types
 import numpy as np
 
@@ -49,35 +49,35 @@ class BmiHeat(Bmi):
         self._model = None
 
     def get_var_type (self, var_name):
-        return str(self.get_value_ptr(var_name).dtype)
+        return str(self.get_value_ref(var_name).dtype)
 
     def get_var_units(self, var_name):
         return self._var_units[var_name]
 
     def get_var_nbytes(self, var_name):
-        return self.get_value_ptr(var_name).nbytes
+        return self.get_value_ref(var_name).nbytes
 
     def get_grid_rank(self, var_name):
-        return self.get_value_ptr(var_name).ndim
+        return self.get_value_ref(var_name).ndim
 
     def get_grid_size(self, var_name):
-        return self.get_value_ptr(var_name).size
+        return self.get_value_ref(var_name).size
 
-    def get_value_ptr(self, var_name):
+    def get_value_ref(self, var_name):
         return self._values[var_name]
 
     def get_value(self, var_name):
-        return self.get_value_ptr(var_name).copy()
+        return self.get_value_ref(var_name).copy()
 
     def get_value_at_indices(self, var_name, indices):
-        return self.get_value_ptr(var_name).take(indices)
+        return self.get_value_ref(var_name).take(indices)
 
     def set_value(self, var_name, src):
-        val = self.get_value_ptr(var_name)
+        val = self.get_value_ref(var_name)
         val[:] = src
 
     def set_value_at_indices(self, var_name, src, indices):
-        val = self.get_value_ptr(var_name)
+        val = self.get_value_ref(var_name)
         val.flat[indices] = src
 
     def get_component_name(self):
@@ -90,7 +90,7 @@ class BmiHeat(Bmi):
         return self._output_var_names
 
     def get_grid_shape (self, var_name):
-        return self.get_value_ptr(var_name).shape
+        return self.get_value_ref(var_name).shape
 
     def get_grid_spacing(self, var_name):
         if var_name in self._values:

--- a/heat/bmi_heat.py
+++ b/heat/bmi_heat.py
@@ -16,14 +16,14 @@ class BmiHeat(Bmi):
         self._model = None
         self._values = {}
 
-    def initialize(self, config_file=None):
-        if config_file is None:
+    def initialize(self, filename=None):
+        if filename is None:
             self._model = Heat()
-        elif isinstance(config_file, types.StringTypes):
-            with open(config_file, 'r') as fp:
+        elif isinstance(filename, types.StringTypes):
+            with open(filename, 'r') as fp:
                 self._model = Heat.from_file_like(fp.read())
         else:
-            self._model = Heat.from_file_like(config_file)
+            self._model = Heat.from_file_like(filename)
 
         self._values = {
             'plate_surface__temperature': self._model.z,

--- a/heat/tests/test_get_value.py
+++ b/heat/tests/test_get_value.py
@@ -57,7 +57,7 @@ def test_value_size():
     model.initialize()
 
     z = model.get_value_ptr('plate_surface__temperature')
-    assert_equal(model.get_var_size('plate_surface__temperature'), z.size)
+    assert_equal(model.get_grid_size('plate_surface__temperature'), z.size)
 
 
 def test_value_nbytes():

--- a/heat/tests/test_get_value.py
+++ b/heat/tests/test_get_value.py
@@ -10,7 +10,7 @@ def test_get_initial_value():
     model = BmiHeat()
     model.initialize()
 
-    z0 = model.get_value_ptr('plate_surface__temperature')
+    z0 = model.get_value_ref('plate_surface__temperature')
     assert_array_less(z0, 1.)
     assert_array_less(0., z0)
 
@@ -30,7 +30,7 @@ def test_get_value_reference():
     model = BmiHeat()
     model.initialize()
 
-    z0 = model.get_value_ptr('plate_surface__temperature')
+    z0 = model.get_value_ref('plate_surface__temperature')
     z1 = model.get_value('plate_surface__temperature')
 
     assert_is_not(z0, z1)
@@ -39,14 +39,14 @@ def test_get_value_reference():
     for _ in xrange(10):
         model.update()
 
-    assert_is(z0, model.get_value_ptr('plate_surface__temperature'))
+    assert_is(z0, model.get_value_ref('plate_surface__temperature'))
 
 
 def test_get_value_at_indices():
     model = BmiHeat()
     model.initialize()
 
-    z0 = model.get_value_ptr('plate_surface__temperature')
+    z0 = model.get_value_ref('plate_surface__temperature')
     z1 = model.get_value_at_indices('plate_surface__temperature', [0, 2, 4])
 
     assert_array_almost_equal(z0.take((0, 2, 4)), z1)
@@ -56,7 +56,7 @@ def test_value_size():
     model = BmiHeat()
     model.initialize()
 
-    z = model.get_value_ptr('plate_surface__temperature')
+    z = model.get_value_ref('plate_surface__temperature')
     assert_equal(model.get_grid_size('plate_surface__temperature'), z.size)
 
 
@@ -64,5 +64,5 @@ def test_value_nbytes():
     model = BmiHeat()
     model.initialize()
 
-    z = model.get_value_ptr('plate_surface__temperature')
+    z = model.get_value_ref('plate_surface__temperature')
     assert_equal(model.get_var_nbytes('plate_surface__temperature'), z.nbytes)

--- a/heat/tests/test_grid_info.py
+++ b/heat/tests/test_grid_info.py
@@ -25,7 +25,7 @@ def test_grid_var_units():
 def test_grid_var_rank():
     model = BmiHeat()
     model.initialize()
-    assert_equal(model.get_var_rank('plate_surface__temperature'), 2)
+    assert_equal(model.get_grid_rank('plate_surface__temperature'), 2)
 
 
 def test_grid_var_shape():

--- a/heat/tests/test_set_value.py
+++ b/heat/tests/test_set_value.py
@@ -10,12 +10,12 @@ def test_set_value():
     model = BmiHeat()
     model.initialize()
 
-    z0 = model.get_value_ptr('plate_surface__temperature')
+    z0 = model.get_value_ref('plate_surface__temperature')
     z1 = np.zeros_like(z0) - 1
 
     model.set_value('plate_surface__temperature', z1)
 
-    new_z = model.get_value_ptr('plate_surface__temperature')
+    new_z = model.get_value_ref('plate_surface__temperature')
 
     assert_is(new_z, z0)
     assert_is_not(new_z, z1)
@@ -26,10 +26,10 @@ def test_set_value_at_indices():
     model = BmiHeat()
     model.initialize()
 
-    z0 = model.get_value_ptr('plate_surface__temperature')
+    z0 = model.get_value_ref('plate_surface__temperature')
 
     model.set_value_at_indices('plate_surface__temperature', [-1, -1, -1],
                                [0, 2, 4])
 
-    new_z = model.get_value_ptr('plate_surface__temperature')
+    new_z = model.get_value_ref('plate_surface__temperature')
     assert_array_almost_equal(new_z.take((0, 2, 4)), -1.)


### PR DESCRIPTION
The bulk of the changes in this pull request are the addition of [numpydoc](https://github.com/numpy/numpydoc/) docstrings to the methods of the BMI classes, following the instructions in the [guide](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt).

I also:
- moved `get_var_rank` to `get_grid_rank`
- moved `get_var_size` to `get_grid_size`
- added the `get_var_grid` method
- changed the input parameter for the `get_grid_*` methods to `grid_id`, from `long_var_name`
- updated the `BmiHeat` class and all the unit tests that use these methods
