### PR TITLE
Use Python instead of Homebrew to install package

### DIFF
--- a/.bmi/api.yaml
+++ b/.bmi/api.yaml
@@ -5,6 +5,4 @@ package: heat
 class: BmiHeat
 
 build:
-  brew:
-    formula: csdms/tools/bmi-python
-    options: "--HEAD"
+  - python setup.py install


### PR DESCRIPTION
Only because this isn't listed in the **csdms/homebrew-tools** repo.
