### PR TITLE
Change weight of coefficient in heat equation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,9 @@ before_install:
   fi
 - |
   if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    curl https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh > $HOME/miniconda.sh
+    curl https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh > $HOME/miniconda.sh
   else
-    curl https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh > $HOME/miniconda.sh
+    curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh > $HOME/miniconda.sh
   fi
 - bash $HOME/miniconda.sh -b -p $HOME/anaconda
 - export PATH="$HOME/anaconda/bin:$PATH"

--- a/heat/heat.py
+++ b/heat/heat.py
@@ -41,7 +41,7 @@ def solve_2d(temp, spacing, out=None, alpha=1.0, time_step=1.0):
         np.array([[0.0, dy2, 0.0], [dx2, -2.0 * (dx2 + dy2), dx2], [0.0, dy2, 0.0]])
         * alpha
         * time_step
-        / (2.0*(dx2 * dy2))
+        / (2.0 * (dx2 * dy2))
     )
 
     if out is None:

--- a/heat/heat.py
+++ b/heat/heat.py
@@ -31,7 +31,7 @@ def solve_2d(temp, spacing, out=None, alpha=1.0, time_step=1.0):
     >>> from heat import solve_2d
     >>> z0 = np.zeros((3, 3))
     >>> z0[1:-1, 1:-1] = 1.
-    >>> solve_2d(z0, (1., 1.), alpha=.125)
+    >>> solve_2d(z0, (1., 1.), alpha=.25)
     array([[0. , 0. , 0. ],
            [0. , 0.5, 0. ],
            [0. , 0. , 0. ]])
@@ -41,7 +41,7 @@ def solve_2d(temp, spacing, out=None, alpha=1.0, time_step=1.0):
         np.array([[0.0, dy2, 0.0], [dx2, -2.0 * (dx2 + dy2), dx2], [0.0, dy2, 0.0]])
         * alpha
         * time_step
-        / (dx2 * dy2)
+        / (2.0*(dx2 * dy2))
     )
 
     if out is None:


### PR DESCRIPTION
This PR includes a slight change to the way temperature is diffused in the `Heat` model.

To show this, start with a 6x8 temperature array with an impulse of 100 at [3,4]:
```
[[ 0.   0.   0.   0.   0.   0.   0.   0. ]
 [ 0.   0.   0.   0.   0.   0.   0.   0. ]
 [ 0.   0.   0.   0.   0.   0.   0.   0. ]
 [ 0.   0.   0.   0. 100.   0.   0.   0. ]
 [ 0.   0.   0.   0.   0.   0.   0.   0. ]
 [ 0.   0.   0.   0.   0.   0.   0.   0. ]]
``` 

Advance the model by one time step.
In the original formulation, this gives:
```
[[ 0.   0.   0.   0.   0.   0.   0.   0. ]
 [ 0.   0.   0.   0.   0.   0.   0.   0. ]
 [ 0.   0.   0.   0.  25.   0.   0.   0. ]
 [ 0.   0.   0.  25.   0.  25.   0.   0. ]
 [ 0.   0.   0.   0.  25.   0.   0.   0. ]
 [ 0.   0.   0.   0.   0.   0.   0.   0. ]]
```

In the updated formulation, this gives:
```
[[ 0.   0.   0.   0.   0.   0.   0.   0. ]
 [ 0.   0.   0.   0.   0.   0.   0.   0. ]
 [ 0.   0.   0.   0.  12.5  0.   0.   0. ]
 [ 0.   0.   0.  12.5 50.  12.5  0.   0. ]
 [ 0.   0.   0.   0.  12.5  0.   0.   0. ]
 [ 0.   0.   0.   0.   0.   0.   0.   0. ]]
```

In each case, temperature is conserved, but in the second case, the diffusion is less rapid.