### PR TITLE
Match bmipy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ os:
 - osx
 env:
   matrix:
-  - CONDA_ENV=3.7
-  - CONDA_ENV=3.6
+  - CONDA_ENV=3.8
+  - CONDA_ENV=3.9
 sudo: false
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,10 +49,13 @@ before_install:
 - export PATH="$HOME/anaconda/bin:$PATH"
 - hash -r
 - conda config --set always_yes yes --set changeps1 no
-- conda create -n test_env python=$CONDA_ENV
+- conda create -n test_env python=$CONDA_ENV --file=requirements.txt -c conda-forge
 - source activate test_env
 install:
-- pip install . -r requirements.txt
+- pip install .
+before_script:
+- conda install --file=requirements-testing.txt -c conda-forge
 script:
 - pytest --cov=heat --cov-report=xml:$(pwd)/coverage.xml -vvv
+- bmi-test heat:BmiHeat --config-file=./examples/heat.yaml --root-dir=./examples -vvv
 after_success: coveralls

--- a/examples/heat.yaml
+++ b/examples/heat.yaml
@@ -1,0 +1,11 @@
+# Heat model configuration
+shape:
+  - 6
+  - 8
+spacing:
+  - 1.0
+  - 1.0
+origin:
+  - 0.0
+  - 0.0
+alpha: 1.0

--- a/heat/bmi_heat.py
+++ b/heat/bmi_heat.py
@@ -167,7 +167,7 @@ class BmiHeat(Bmi):
         int
             Rank of grid.
         """
-        return len(self.get_grid_shape(grid_id))
+        return len(self._model.shape)
 
     def get_grid_size(self, grid_id):
         """Size of grid.
@@ -182,7 +182,7 @@ class BmiHeat(Bmi):
         int
             Size of grid.
         """
-        return np.prod(self.get_grid_shape(grid_id))
+        return int(np.prod(self._model.shape))
 
     def get_value_ptr(self, var_name):
         """Reference to values.

--- a/heat/bmi_heat.py
+++ b/heat/bmi_heat.py
@@ -2,7 +2,6 @@
 """Basic Model Interface implementation for the 2D heat model."""
 
 import numpy as np
-
 from bmipy import Bmi
 
 from .heat import Heat

--- a/heat/bmi_heat.py
+++ b/heat/bmi_heat.py
@@ -279,18 +279,21 @@ class BmiHeat(Bmi):
         """Get names of output variables."""
         return self._output_var_names
 
-    def get_grid_shape(self, grid_id):
+    def get_grid_shape(self, grid_id, shape):
         """Number of rows and columns of uniform rectilinear grid."""
         var_name = self._grids[grid_id][0]
-        return self.get_value_ptr(var_name).shape
+        shape[:] = self.get_value_ptr(var_name).shape
+        return shape
 
-    def get_grid_spacing(self, grid_id):
+    def get_grid_spacing(self, grid_id, spacing):
         """Spacing of rows and columns of uniform rectilinear grid."""
-        return self._model.spacing
+        spacing[:] = self._model.spacing
+        return spacing
 
-    def get_grid_origin(self, grid_id):
+    def get_grid_origin(self, grid_id, origin):
         """Origin of uniform rectilinear grid."""
-        return self._model.origin
+        origin[:] = self._model.origin
+        return origin
 
     def get_grid_type(self, grid_id):
         """Type of grid."""

--- a/heat/bmi_heat.py
+++ b/heat/bmi_heat.py
@@ -49,7 +49,7 @@ class BmiHeat(Bmi):
         self._var_units = {"plate_surface__temperature": "K"}
         self._var_loc = {"plate_surface__temperature": "node"}
         self._grids = {0: ["plate_surface__temperature"]}
-        self._grid_type = {0: "uniform_rectilinear_grid"}
+        self._grid_type = {0: "uniform_rectilinear"}
 
     def update(self):
         """Advance model by one time step."""

--- a/heat/bmi_heat.py
+++ b/heat/bmi_heat.py
@@ -199,28 +199,33 @@ class BmiHeat(Bmi):
         """
         return self._values[var_name]
 
-    def get_value(self, var_name):
+    def get_value(self, var_name, dest):
         """Copy of values.
 
         Parameters
         ----------
         var_name : str
             Name of variable as CSDMS Standard Name.
+        dest : ndarray
+            A numpy array into which to place the values.
 
         Returns
         -------
         array_like
             Copy of values.
         """
-        return self.get_value_ptr(var_name).copy()
+        dest[:] = self.get_value_ptr(var_name).flatten()
+        return dest
 
-    def get_value_at_indices(self, var_name, indices):
+    def get_value_at_indices(self, var_name, dest, indices):
         """Get values at particular indices.
 
         Parameters
         ----------
         var_name : str
             Name of variable as CSDMS Standard Name.
+        dest : ndarray
+            A numpy array into which to place the values.
         indices : array_like
             Array of indices.
 
@@ -229,7 +234,8 @@ class BmiHeat(Bmi):
         array_like
             Values at indices.
         """
-        return self.get_value_ptr(var_name).take(indices)
+        dest[:] = self.get_value_ptr(var_name).take(indices)
+        return dest
 
     def set_value(self, var_name, src):
         """Set model values.

--- a/heat/heat.py
+++ b/heat/heat.py
@@ -86,7 +86,7 @@ class Heat(object):
     ):
         """Create a new heat model.
 
-        Paramters
+        Parameters
         ---------
         shape : array_like, optional
             The shape of the solution grid as (*rows*, *columns*).

--- a/heat/heat.py
+++ b/heat/heat.py
@@ -139,8 +139,13 @@ class Heat(object):
         self._time_step = time_step
 
     @property
-    def spacing(self):
+    def shape(self):
         """Shape of the model grid."""
+        return self._shape
+
+    @property
+    def spacing(self):
+        """Spacing between nodes of the model grid."""
         return self._spacing
 
     @property

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,0 +1,6 @@
+coveralls
+flake8
+pytest
+pytest-cov
+six
+bmi-tester

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-coveralls
-flake8
-pytest
-pytest-cov
-six
+numpy
+scipy
+pyyaml
+bmipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ coveralls
 flake8
 pytest
 pytest-cov
+six

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,3 @@ setup(
     packages=find_packages(),
     cmdclass=versioneer.get_cmdclass(),
 )
-
-

--- a/tests/test_get_value.py
+++ b/tests/test_get_value.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from numpy.testing import assert_array_almost_equal, assert_array_less
+import numpy as np
 
 from heat import BmiHeat
 
@@ -17,8 +18,11 @@ def test_get_value_copy():
     model = BmiHeat()
     model.initialize()
 
-    z0 = model.get_value("plate_surface__temperature")
-    z1 = model.get_value("plate_surface__temperature")
+    dest0 = np.empty(model.get_grid_size(0), dtype=float)
+    dest1 = np.empty(model.get_grid_size(0), dtype=float)
+
+    z0 = model.get_value("plate_surface__temperature", dest0)
+    z1 = model.get_value("plate_surface__temperature", dest1)
 
     assert z0 is not z1
     assert_array_almost_equal(z0, z1)
@@ -28,11 +32,13 @@ def test_get_value_pointer():
     model = BmiHeat()
     model.initialize()
 
+    dest1 = np.empty(model.get_grid_size(0), dtype=float)
+
     z0 = model.get_value_ptr("plate_surface__temperature")
-    z1 = model.get_value("plate_surface__temperature")
+    z1 = model.get_value("plate_surface__temperature", dest1)
 
     assert z0 is not z1
-    assert_array_almost_equal(z0, z1)
+    assert_array_almost_equal(z0.flatten(), z1)
 
     for _ in range(10):
         model.update()
@@ -44,8 +50,10 @@ def test_get_value_at_indices():
     model = BmiHeat()
     model.initialize()
 
+    dest = np.empty(3, dtype=float)
+
     z0 = model.get_value_ptr("plate_surface__temperature")
-    z1 = model.get_value_at_indices("plate_surface__temperature", [0, 2, 4])
+    z1 = model.get_value_at_indices("plate_surface__temperature", dest, [0, 2, 4])
 
     assert_array_almost_equal(z0.take((0, 2, 4)), z1)
 

--- a/tests/test_grid_info.py
+++ b/tests/test_grid_info.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 import pytest
+import numpy as np
+from numpy.testing import assert_array_equal
 
 from heat import BmiHeat
 
@@ -47,49 +49,34 @@ def test_grid_var_rank():
     assert model.get_grid_rank(grid_id) == 2
 
 
-def test_grid_var_rank_fail():
-    model = BmiHeat()
-    model.initialize()
-    with pytest.raises(KeyError):
-        model.get_grid_rank(invalid_grid_id)
-
-
 def test_grid_var_size():
     model = BmiHeat()
     model.initialize()
     assert model.get_grid_size(grid_id) == 200
 
 
-def test_grid_var_size_fail():
-    model = BmiHeat()
-    model.initialize()
-    with pytest.raises(KeyError):
-        model.get_grid_size(invalid_grid_id)
-
-
 def test_grid_var_shape():
     model = BmiHeat()
     model.initialize()
-    assert model.get_grid_shape(grid_id) == (10, 20)
-
-
-def test_grid_var_shape_fail():
-    model = BmiHeat()
-    model.initialize()
-    with pytest.raises(KeyError):
-        model.get_grid_shape(invalid_grid_id)
+    ndim = model.get_grid_rank(0)
+    shape = np.empty(ndim, dtype=np.int32)
+    assert_array_equal(model.get_grid_shape(grid_id, shape), (10, 20))
 
 
 def test_grid_var_spacing():
     model = BmiHeat()
     model.initialize()
-    assert model.get_grid_spacing(grid_id) == (1.0, 1.0)
+    ndim = model.get_grid_rank(0)
+    spacing = np.empty(ndim, dtype=np.int32)
+    assert_array_equal(model.get_grid_spacing(grid_id, spacing), (1.0, 1.0))
 
 
 def test_grid_var_origin():
     model = BmiHeat()
     model.initialize()
-    assert model.get_grid_origin(grid_id) == (0.0, 0.0)
+    ndim = model.get_grid_rank(0)
+    origin = np.empty(ndim, dtype=np.int32)
+    assert_array_equal(model.get_grid_origin(grid_id, origin), (0.0, 0.0))
 
 
 def test_grid_var_type():
@@ -101,4 +88,4 @@ def test_grid_var_type():
 def test_grid_type():
     model = BmiHeat()
     model.initialize()
-    assert model.get_grid_type(grid_id) == "uniform_rectilinear_grid"
+    assert model.get_grid_type(grid_id) == "uniform_rectilinear"

--- a/tests/test_grid_info.py
+++ b/tests/test_grid_info.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-import pytest
 import numpy as np
 from numpy.testing import assert_array_equal
 

--- a/tests/test_irf.py
+++ b/tests/test_irf.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from io import StringIO
 
-from numpy.testing import assert_almost_equal, assert_array_less
+from numpy.testing import assert_almost_equal, assert_array_less, assert_array_equal
 import numpy as np
 import yaml
 
@@ -36,8 +36,9 @@ def test_initialize_defaults():
     model.initialize()
 
     assert_almost_equal(model.get_current_time(), 0.0)
-    assert_array_less(model.get_value("plate_surface__temperature"), 1.0)
-    assert_array_less(0.0, model.get_value("plate_surface__temperature"))
+    z0 = model.get_value_ptr("plate_surface__temperature")
+    assert_array_less(z0, 1.0)
+    assert_array_less(0.0, z0)
 
 
 def test_initialize_from_file_like():
@@ -45,7 +46,10 @@ def test_initialize_from_file_like():
     model = BmiHeat()
     model.initialize(config)
 
-    assert model.get_grid_shape(0) == (7, 5)
+    ndim = model.get_grid_rank(0)
+    shape = np.empty(ndim, dtype=np.int32)
+
+    assert_array_equal(model.get_grid_shape(0, shape), (7, 5))
 
 
 def test_initialize_from_file():
@@ -62,7 +66,10 @@ def test_initialize_from_file():
 
     os.remove(name)
 
-    assert model.get_grid_shape(0) == (7, 5)
+    ndim = model.get_grid_rank(0)
+    shape = np.empty(ndim, dtype=np.int32)
+
+    assert_array_equal(model.get_grid_shape(0, shape), (7, 5))
 
 
 def test_update():


### PR DESCRIPTION
This PR updates the BMI for the *heat* model to more closely match the signatures of the BMI functions from the [bmi-python](https://github.com/csdms/bmi-python) repo. In particular, the

* get_grid_shape,
* get_grid_spacing,
* get_grid_origin,
* get_value, and
* get_value_at_indices

functions all take an output array parameter.

As a convenience, a *shape* property was added to the Heat class. This makes the *get_grid_rank* and *get_grid_size* functions easier to implement.

The unit tests were updated to match the updated BMI.