### PR TITLE
Implement get_grid_node_count function

### DIFF
--- a/heat/bmi_heat.py
+++ b/heat/bmi_heat.py
@@ -334,7 +334,19 @@ class BmiHeat(Bmi):
         raise NotImplementedError("get_grid_face_nodes")
 
     def get_grid_node_count(self, grid):
-        raise NotImplementedError("get_grid_node_count")
+        """Number of grid nodes.
+
+        Parameters
+        ----------
+        grid : int
+            Identifier of a grid.
+
+        Returns
+        -------
+        int
+            Size of grid.
+        """
+        return self.get_grid_size(grid)
 
     def get_grid_nodes_per_face(self, grid, nodes_per_face):
         raise NotImplementedError("get_grid_nodes_per_face")

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,6 @@ combine_as_imports=True
 line_length=88
 
 [flake8]
-exclude = docs heat/_version.py
 ignore =
 	E203
 	E501
@@ -33,3 +32,6 @@ max-line-length = 88
 
 [pylint]
 disable = missing-docstring,line-too-long
+
+[zest.releaser]
+tag-format = v{version}


### PR DESCRIPTION
The BMI *get_grid_node_count* function is intended to succeed to the *get_grid_size* function, and it is already required in pymt. This PR implements *get_grid_node_count*, calling the existing *get_grid_size* function.