### PR TITLE
Use random subpackage from numpy instead of scipy

### DIFF
--- a/heat/heat.py
+++ b/heat/heat.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import yaml
-from scipy import ndimage, random
+from scipy import ndimage
 
 
 def solve_2d(temp, spacing, out=None, alpha=1.0, time_step=1.0):
@@ -104,7 +104,7 @@ class Heat(object):
         self._alpha = alpha
         self._time_step = min(spacing) ** 2 / (4.0 * self._alpha)
 
-        self._temperature = random.random(self._shape)
+        self._temperature = np.random.random(self._shape)
         self._next_temperature = np.empty_like(self._temperature)
 
     @property


### PR DESCRIPTION
This is a tiny, yet interesting, pull request. In scipy 1.9, the *random* subpackage is no longer. It's there in scipy 1.8. I couldn't find mention of why it has been removed. So, to be careful, I instead used the equivalent `random.random` function from numpy.