### PR TITLE
Use setup-python for the ci tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,16 +24,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - uses: conda-incubator/setup-miniconda@v3
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          miniforge-version: latest
           python-version: ${{ matrix.python-version }}
-
-      - name: Show conda installation info
-        run: |
-          conda info
-          conda list
 
       - name: Build and install package
         run: pip install -e .[testing]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Build and install package
-        run: pip install -e .[testing]
+        run: |
+          pip install setuptools==75.1.0
+          pip install -e .[testing]
 
       - name: Test
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request replaces *setup-miniconda* with *setup-python* for the tests.